### PR TITLE
Remove babel-node command from production server script

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "test:pattern": "cross-env NODE_ENV=test mocha --env.dev --watch --opts ./mocha.opts --grep $pattern",
     "test:proxy-example": "cross-env NODE_ENV=test mocha --env.dev --proxy --opts ./mocha.opts \"./test/integration/proxy/proxy-example.js\"",
     "wdio": "cross-env NODE_ENV=test cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 babel-node ./node_modules/.bin/wdio ./test/wdio.conf.js --env.prod",
-    "server": "cross-env NODE_ENV=production babel-node ./server",
+    "server": "cross-env NODE_ENV=production node ./server",
     "start": "babel-node ./server --hot"
   }
 }


### PR DESCRIPTION
Per Babel docs, the `babel-node` command is not meant for production use:
https://babeljs.io/docs/usage/cli/#babel-node


>Not meant for production use
You should not be using babel-node in production. It is unnecessarily heavy, with high memory usage due to the cache being stored in memory. You will also always experience a startup performance penalty as the entire app needs to be compiled on the fly.
